### PR TITLE
Add spin duration options

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -46,3 +46,21 @@ body {
 .result {
     margin-top: 1rem;
 }
+
+.options-container {
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0.5rem;
+}
+
+.options-button {
+    padding: 0.25rem 0.5rem;
+}
+
+.options-window {
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    margin-top: 0.5rem;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ export default function HomePage() {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [rotation, setRotation] = useState(0);
     const [seconds, setSeconds] = useState(5);
+    const [showOptions, setShowOptions] = useState(false);
 
     useEffect(() => {
         getGames()
@@ -66,6 +67,24 @@ export default function HomePage() {
 
     return (
         <main className="container">
+            <div className="options-container">
+                <button className="options-button" onClick={() => setShowOptions(!showOptions)}>
+                    Options
+                </button>
+                {showOptions && (
+                    <div className="options-window">
+                        <label htmlFor="duration">Spin Duration: {seconds}s</label>
+                        <input
+                            id="duration"
+                            type="range"
+                            min={5}
+                            max={120}
+                            value={seconds}
+                            onChange={(e) => setSeconds(Number(e.target.value))}
+                        />
+                    </div>
+                )}
+            </div>
             <h1>Steam New Releases Wheel</h1>
             <div className="wheel-wrapper">
                 <div className="pointer" />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ export default function HomePage() {
     const [rotation, setRotation] = useState(0);
     const [seconds, setSeconds] = useState(5);
     const [showOptions, setShowOptions] = useState(false);
+    const [isSpinning, setIsSpinning] = useState(false);
 
     useEffect(() => {
         getGames()
@@ -53,15 +54,18 @@ export default function HomePage() {
     }, [games]);
 
     const spin = () => {
-        if (!games.length) return;
+        setSelected(null);
+        if (!games.length || isSpinning) return;
         const randIndex = Math.floor(Math.random() * games.length);
         const anglePerSlice = 360 / games.length;
         const currentCenter = (rotation + randIndex * anglePerSlice + anglePerSlice / 2) % 360;
         const delta = 360 + 180 * 5 + 90 - currentCenter + seconds * 360;
         setRotation(rotation + delta);
+        setIsSpinning(true);
         setTimeout(() => {
             console.log(`Selected game: ${games[randIndex].name}`);
             setSelected(games[randIndex]);
+            setIsSpinning(false);
         }, seconds * 1000);
     };
 
@@ -81,6 +85,7 @@ export default function HomePage() {
                             max={120}
                             value={seconds}
                             onChange={(e) => setSeconds(Number(e.target.value))}
+                            disabled={isSpinning}
                         />
                     </div>
                 )}
@@ -97,7 +102,7 @@ export default function HomePage() {
                     />
                 </div>
             </div>
-            <button className="spin" onClick={spin}>
+            <button className="spin" onClick={spin} disabled={isSpinning}>
                 Spin
             </button>
             {selected && (


### PR DESCRIPTION
## Summary
- add Options panel with slider to control spin duration
- style new options UI

## Testing
- `npm install` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684085270864832cbce20812a0bbad75