### PR TITLE
Add GeForce Now games page

### DIFF
--- a/app/components/LoadingWheel.tsx
+++ b/app/components/LoadingWheel.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export default function LoadingWheel() {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        const radius = canvas.width / 2;
+        const segments = 8;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        for (let i = 0; i < segments; i++) {
+            const angleStart = (i / segments) * Math.PI * 2;
+            const angleEnd = ((i + 1) / segments) * Math.PI * 2;
+            ctx.beginPath();
+            ctx.moveTo(radius, radius);
+            ctx.arc(radius, radius, radius, angleStart, angleEnd);
+            ctx.fillStyle = i % 2 ? "#ffdf6b" : "#fbc531";
+            ctx.fill();
+        }
+    }, []);
+
+    return (
+        <div className="wheel-wrapper small">
+            <div className="pointer small" />
+            <div className="wheel-container">
+                <canvas
+                    ref={canvasRef}
+                    width={200}
+                    height={200}
+                    className="loading-spinner"
+                />
+            </div>
+        </div>
+    );
+}

--- a/app/components/Wheel.tsx
+++ b/app/components/Wheel.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export interface WheelProps<T> {
+    items: T[];
+    getLabel: (item: T) => string;
+    characterLimit?: number;
+    hideText?: boolean;
+    renderResult?: (item: T) => React.ReactNode;
+    title: string;
+}
+
+export default function Wheel<T>({
+    items,
+    getLabel,
+    characterLimit = 14,
+    hideText = false,
+    renderResult,
+    title,
+}: WheelProps<T>) {
+    const [selected, setSelected] = useState<T | null>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const [rotation, setRotation] = useState(0);
+    const [seconds, setSeconds] = useState(5);
+    const [showOptions, setShowOptions] = useState(false);
+    const [isSpinning, setIsSpinning] = useState(false);
+
+    useEffect(() => {
+        if (!items.length) return;
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        const radius = canvas.width / 2;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        items.forEach((item, i) => {
+            const angleStart = (i / items.length) * Math.PI * 2;
+            const angleEnd = ((i + 1) / items.length) * Math.PI * 2;
+            ctx.beginPath();
+            ctx.moveTo(radius, radius);
+            ctx.arc(radius, radius, radius, angleStart, angleEnd);
+            ctx.fillStyle = i % 2 ? "#ffdf6b" : "#fbc531";
+            ctx.fill();
+            if (!hideText) {
+                ctx.save();
+                ctx.translate(radius, radius);
+                ctx.rotate(angleStart + (angleEnd - angleStart) / 2);
+                ctx.textAlign = "right";
+                ctx.fillStyle = "#000";
+                const fontSize = 14;
+                ctx.font = `${fontSize}px sans-serif`;
+                const label = getLabel(item);
+                const text =
+                    label.length > characterLimit
+                        ? label.slice(0, characterLimit) + "..."
+                        : label;
+                ctx.fillText(text, radius - 10, fontSize * 0.3);
+                ctx.restore();
+            }
+        });
+    }, [items, hideText, getLabel, characterLimit]);
+
+    const spin = () => {
+        setSelected(null);
+        if (!items.length || isSpinning) return;
+        const randIndex = Math.floor(Math.random() * items.length);
+        const anglePerSlice = 360 / items.length;
+        const currentCenter = (rotation + randIndex * anglePerSlice + anglePerSlice / 2) % 360;
+        const delta = 360 + 180 * 5 + 90 - currentCenter + seconds * 360;
+        setRotation(rotation + delta);
+        setIsSpinning(true);
+        setTimeout(() => {
+            setSelected(items[randIndex]);
+            setIsSpinning(false);
+        }, seconds * 1000);
+    };
+
+    return (
+        <main className="container">
+            <div className="options-container">
+                <button className="options-button" onClick={() => setShowOptions(!showOptions)}>
+                    Options
+                </button>
+                {showOptions && (
+                    <div className="options-window">
+                        <label htmlFor="duration">Spin Duration: {seconds}s</label>
+                        <input
+                            id="duration"
+                            type="range"
+                            min={5}
+                            max={120}
+                            value={seconds}
+                            onChange={(e) => setSeconds(Number(e.target.value))}
+                            disabled={isSpinning}
+                        />
+                    </div>
+                )}
+            </div>
+            <h1>{title}</h1>
+            <div className="wheel-wrapper">
+                <div className="pointer" />
+                <div className="wheel-container">
+                    <canvas
+                        ref={canvasRef}
+                        width={500}
+                        height={500}
+                        style={{ transform: `rotate(${rotation}deg)`, transition: `transform ${seconds}s ease-out` }}
+                    />
+                </div>
+            </div>
+            <button className="spin" onClick={spin} disabled={isSpinning}>
+                Spin
+            </button>
+            {selected && (
+                <p className="result">
+                    {renderResult ? renderResult(selected) : <>You got: {getLabel(selected)}</>}
+                </p>
+            )}
+        </main>
+    );
+}
+

--- a/app/components/Wheel.tsx
+++ b/app/components/Wheel.tsx
@@ -73,7 +73,8 @@ export default function Wheel<T>({
         const selectedIndex = Math.floor(Math.random() * items.length);
         const anglePerSlice = 360 / wedgeCount;
         const currentCenter = (rotation + wedgeIndex * anglePerSlice + anglePerSlice / 2) % 360;
-        const delta = 360 + 180 * 5 + 90 - currentCenter + seconds * 360;
+        // Align the selected wedge with the pointer at the top of the wheel
+        const delta = 360 + 180 * 5 + 270 - currentCenter + seconds * 360;
         setRotation(rotation + delta);
         setIsSpinning(true);
         setTimeout(() => {

--- a/app/components/Wheel.tsx
+++ b/app/components/Wheel.tsx
@@ -26,6 +26,8 @@ export default function Wheel<T>({
     const [showOptions, setShowOptions] = useState(false);
     const [isSpinning, setIsSpinning] = useState(false);
 
+    const MAX_WEDGES = 100;
+
     useEffect(() => {
         if (!items.length) return;
         const canvas = canvasRef.current;
@@ -34,9 +36,11 @@ export default function Wheel<T>({
         if (!ctx) return;
         const radius = canvas.width / 2;
         ctx.clearRect(0, 0, canvas.width, canvas.height);
-        items.forEach((item, i) => {
-            const angleStart = (i / items.length) * Math.PI * 2;
-            const angleEnd = ((i + 1) / items.length) * Math.PI * 2;
+        const wedgeCount = Math.min(items.length, MAX_WEDGES);
+        const displayItems = items.slice(0, wedgeCount);
+        displayItems.forEach((item, i) => {
+            const angleStart = (i / wedgeCount) * Math.PI * 2;
+            const angleEnd = ((i + 1) / wedgeCount) * Math.PI * 2;
             ctx.beginPath();
             ctx.moveTo(radius, radius);
             ctx.arc(radius, radius, radius, angleStart, angleEnd);
@@ -64,14 +68,16 @@ export default function Wheel<T>({
     const spin = () => {
         setSelected(null);
         if (!items.length || isSpinning) return;
-        const randIndex = Math.floor(Math.random() * items.length);
-        const anglePerSlice = 360 / items.length;
-        const currentCenter = (rotation + randIndex * anglePerSlice + anglePerSlice / 2) % 360;
+        const wedgeCount = Math.min(items.length, MAX_WEDGES);
+        const wedgeIndex = Math.floor(Math.random() * wedgeCount);
+        const selectedIndex = Math.floor(Math.random() * items.length);
+        const anglePerSlice = 360 / wedgeCount;
+        const currentCenter = (rotation + wedgeIndex * anglePerSlice + anglePerSlice / 2) % 360;
         const delta = 360 + 180 * 5 + 90 - currentCenter + seconds * 360;
         setRotation(rotation + delta);
         setIsSpinning(true);
         setTimeout(() => {
-            setSelected(items[randIndex]);
+            setSelected(items[selectedIndex]);
             setIsSpinning(false);
         }, seconds * 1000);
     };

--- a/app/geforce-now/loading.tsx
+++ b/app/geforce-now/loading.tsx
@@ -1,0 +1,10 @@
+import LoadingWheel from "../components/LoadingWheel";
+
+export default function Loading() {
+    return (
+        <main className="container">
+            <p>Loading...</p>
+            <LoadingWheel />
+        </main>
+    );
+}

--- a/app/geforce-now/page.tsx
+++ b/app/geforce-now/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Wheel from "../components/Wheel";
+import { fetchAllGames, Game } from "../lib/geforce";
+
+const characterLimit = 14;
+
+export default function GeforceNowPage() {
+    const [games, setGames] = useState<Game[]>([]);
+
+    useEffect(() => {
+        fetchAllGames()
+            .then((items) => setGames(items))
+            .catch((err) => console.error(err));
+    }, []);
+
+    const hideText = games.length > 100;
+
+    return (
+        <Wheel
+            items={games}
+            getLabel={(g) => g.title}
+            characterLimit={characterLimit}
+            hideText={hideText}
+            title="GeForce Now Games Wheel"
+        />
+    );
+}

--- a/app/geforce-now/page.tsx
+++ b/app/geforce-now/page.tsx
@@ -3,19 +3,26 @@
 import { useEffect, useState } from "react";
 import Wheel from "../components/Wheel";
 import { fetchAllGames, Game } from "../lib/geforce";
+import Loading from "../loading";
 
 const characterLimit = 14;
 
 export default function GeforceNowPage() {
     const [games, setGames] = useState<Game[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
         fetchAllGames()
             .then((items) => setGames(items))
-            .catch((err) => console.error(err));
+            .catch((err) => console.error(err))
+            .finally(() => setIsLoading(false));
     }, []);
 
     const hideText = games.length > 100;
+
+    if (isLoading) {
+        return <Loading />;
+    }
 
     return (
         <Wheel

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,6 +17,11 @@ body {
     height: 500px;
 }
 
+.wheel-wrapper.small {
+    width: 200px;
+    height: 200px;
+}
+
 .wheel-container {
     width: 100%;
     height: 100%;
@@ -37,6 +42,13 @@ body {
     border-right: 20px solid transparent;
     border-top: 20px solid #e84118;
     transform: translateX(-50%);
+}
+
+.pointer.small {
+    top: -10px;
+    border-left-width: 10px;
+    border-right-width: 10px;
+    border-top-width: 10px;
 }
 
 .spin {
@@ -69,6 +81,19 @@ body {
 canvas {
     width: 100%;
     height: 100%;
+}
+
+.loading-spinner {
+    animation: loading-spin 2s linear infinite;
+}
+
+@keyframes loading-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 @media (max-width: 600px) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -33,8 +33,7 @@ body {
 .pointer {
     z-index: 10;
     position: absolute;
-    /* align the tip of the pointer with the edge of the wheel */
-    top: -20px;
+    top: -10px;
     left: 50%;
     width: 0;
     height: 0;

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,7 +28,8 @@ body {
 .pointer {
     z-index: 10;
     position: absolute;
-    top: -10px;
+    /* align the tip of the pointer with the edge of the wheel */
+    top: -20px;
     left: 50%;
     width: 0;
     height: 0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
     return (
         <html lang="en">
-            <body>{children}</body>
+            <body>
+                <nav style={{ marginBottom: "1rem" }}>
+                    <a href="/" style={{ marginRight: "1rem" }}>Steam</a>
+                    <a href="/geforce-now">GeForce Now</a>
+                </nav>
+                {children}
+            </body>
         </html>
     );
 }

--- a/app/lib/geforce.ts
+++ b/app/lib/geforce.ts
@@ -1,0 +1,84 @@
+"use server";
+
+export type Game = {
+    title: string;
+    sortName: string;
+    gfn: {
+        minimumMembershipTierLabel: string;
+    };
+    variants: {
+        appStore: string;
+        publisherName: string;
+    }[];
+};
+
+export type PageInfo = {
+    endCursor: string;
+    hasNextPage: boolean;
+};
+
+export type GamesResponse = {
+    apps: {
+        numberReturned: number;
+        pageInfo: PageInfo;
+        items: Game[];
+    };
+};
+
+const API_URL = "https://api-prod.nvidia.com/services/gfngames/v1/gameList";
+const listSize = 100;
+
+export async function fetchGamesPage(afterCursor?: string): Promise<GamesResponse> {
+    const afterParam = afterCursor ? ` after:"${afterCursor}"` : "";
+    const queryBody = `{ apps(country:"GB" language:"en_GB" first:${listSize}${afterParam}) {\n  numberReturned\n  pageInfo {\n    endCursor\n    hasNextPage\n  }\n  items {\n    title\n    sortName\n    gfn{\n      minimumMembershipTierLabel\n    }\n    variants{\n      appStore\n      publisherName\n    }\n  }\n}}`;
+
+    const response = await fetch(API_URL, {
+        method: "POST",
+        headers: {
+            accept: "*/*",
+            "accept-language": "en-GB,en-US;q=0.9,en;q=0.8,sq;q=0.7",
+            "cache-control": "no-cache",
+            "content-type": "application/json;charset=UTF-8",
+            origin: "https://www.nvidia.com",
+            pragma: "no-cache",
+            priority: "u=0, i",
+            referer: "https://www.nvidia.com/",
+            "sec-ch-ua": '"Chromium";v="136", "Google Chrome";v="136", "Not.A/Brand";v="99"',
+            "sec-ch-ua-mobile": "?0",
+            "sec-ch-ua-platform": '"macOS"',
+            "sec-fetch-dest": "empty",
+            "sec-fetch-mode": "cors",
+            "sec-fetch-site": "same-site",
+            "user-agent":
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36",
+        },
+        body: queryBody,
+    });
+
+    if (!response.ok) {
+        const text = await response.text();
+        throw new Error(`Failed to fetch games: ${response.status} ${response.statusText}\n${text}`);
+    }
+
+    const data = await response.json();
+    return data.data as GamesResponse;
+}
+
+export async function fetchAllGames(): Promise<Game[]> {
+    let allGames: Game[] = [];
+    let afterCursor: string | undefined = undefined;
+    let hasNextPage = true;
+
+    while (hasNextPage) {
+        const { apps } = await fetchGamesPage(afterCursor);
+        allGames = allGames.concat(apps.items);
+
+        hasNextPage = apps.pageInfo.hasNextPage;
+        afterCursor = apps.pageInfo.endCursor;
+
+        console.log(`Fetched ${allGames.length} games so far...`);
+    }
+
+    return allGames;
+}
+

--- a/app/lib/geforce.ts
+++ b/app/lib/geforce.ts
@@ -1,5 +1,7 @@
 "use server";
 
+import { cache } from "react";
+
 export type Game = {
     title: string;
     sortName: string;
@@ -34,6 +36,7 @@ export async function fetchGamesPage(afterCursor?: string): Promise<GamesRespons
 
     const response = await fetch(API_URL, {
         method: "POST",
+        next: { revalidate: 60 * 60 * 24 * 3 },
         headers: {
             accept: "*/*",
             "accept-language": "en-GB,en-US;q=0.9,en;q=0.8,sq;q=0.7",
@@ -64,7 +67,7 @@ export async function fetchGamesPage(afterCursor?: string): Promise<GamesRespons
     return data.data as GamesResponse;
 }
 
-export async function fetchAllGames(): Promise<Game[]> {
+export const fetchAllGames = cache(async (): Promise<Game[]> => {
     let allGames: Game[] = [];
     let afterCursor: string | undefined = undefined;
     let hasNextPage = true;
@@ -80,5 +83,5 @@ export async function fetchAllGames(): Promise<Game[]> {
     }
 
     return allGames;
-}
+});
 

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,10 @@
+import LoadingWheel from "./components/LoadingWheel";
+
+export default function Loading() {
+    return (
+        <main className="container">
+            <p>Loading...</p>
+            <LoadingWheel />
+        </main>
+    );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import Wheel from "./components/Wheel";
 import { getGames } from "./lib/steam";
 
 interface Game {
@@ -8,16 +9,8 @@ interface Game {
     name: string;
 }
 
-const characterLimit = 14;
-
 export default function HomePage() {
     const [games, setGames] = useState<Game[]>([]);
-    const [selected, setSelected] = useState<Game | null>(null);
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-    const [rotation, setRotation] = useState(0);
-    const [seconds, setSeconds] = useState(5);
-    const [showOptions, setShowOptions] = useState(false);
-    const [isSpinning, setIsSpinning] = useState(false);
 
     useEffect(() => {
         getGames()
@@ -25,98 +18,14 @@ export default function HomePage() {
             .catch((err) => console.error(err));
     }, []);
 
-    useEffect(() => {
-        if (!games.length) return;
-        const canvas = canvasRef.current;
-        if (!canvas) return;
-        const ctx = canvas.getContext("2d");
-        if (!ctx) return;
-        const radius = canvas.width / 2;
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        games.forEach((game, i) => {
-            const angleStart = (i / games.length) * Math.PI * 2;
-            const angleEnd = ((i + 1) / games.length) * Math.PI * 2;
-            ctx.beginPath();
-            ctx.moveTo(radius, radius);
-            ctx.arc(radius, radius, radius, angleStart, angleEnd);
-            ctx.fillStyle = i % 2 ? "#ffdf6b" : "#fbc531";
-            ctx.fill();
-            ctx.save();
-            ctx.translate(radius, radius);
-            ctx.rotate(angleStart + (angleEnd - angleStart) / 2);
-            ctx.textAlign = "right";
-            ctx.fillStyle = "#000";
-            const fontSize = 14;
-            ctx.font = `${fontSize}px sans-serif`;
-            const text =
-                game.name.length > characterLimit
-                    ? game.name.slice(0, characterLimit) + "..."
-                    : game.name;
-            ctx.fillText(text, radius - 10, fontSize * 0.3);
-            ctx.restore();
-        });
-    }, [games]);
-
-    const spin = () => {
-        setSelected(null);
-        if (!games.length || isSpinning) return;
-        const randIndex = Math.floor(Math.random() * games.length);
-        const anglePerSlice = 360 / games.length;
-        const currentCenter = (rotation + randIndex * anglePerSlice + anglePerSlice / 2) % 360;
-        const delta = 360 + 180 * 5 + 90 - currentCenter + seconds * 360;
-        setRotation(rotation + delta);
-        setIsSpinning(true);
-        setTimeout(() => {
-            console.log(`Selected game: ${games[randIndex].name}`);
-            setSelected(games[randIndex]);
-            setIsSpinning(false);
-        }, seconds * 1000);
-    };
-
     return (
-        <main className="container">
-            <div className="options-container">
-                <button className="options-button" onClick={() => setShowOptions(!showOptions)}>
-                    Options
-                </button>
-                {showOptions && (
-                    <div className="options-window">
-                        <label htmlFor="duration">Spin Duration: {seconds}s</label>
-                        <input
-                            id="duration"
-                            type="range"
-                            min={5}
-                            max={120}
-                            value={seconds}
-                            onChange={(e) => setSeconds(Number(e.target.value))}
-                            disabled={isSpinning}
-                        />
-                    </div>
-                )}
-            </div>
-            <h1>Steam New Releases Wheel</h1>
-            <div className="wheel-wrapper">
-                <div className="pointer" />
-                <div className="wheel-container">
-                    <canvas
-                        ref={canvasRef}
-                        width={500}
-                        height={500}
-                        style={{ transform: `rotate(${rotation}deg)`, transition: `transform ${seconds}s ease-out` }}
-                    />
-                </div>
-            </div>
-            <button className="spin" onClick={spin} disabled={isSpinning}>
-                Spin
-            </button>
-            {selected && (
-                <p className="result">
-                    You got:{" "}
-                    <a href={`https://store.steampowered.com/app/${selected.id}`} target="_blank" rel="noreferrer">
-                        {selected.name}
-                    </a>
-                </p>
+        <Wheel
+            items={games}
+            getLabel={(g) => g.name}
+            title="Steam New Releases Wheel"
+            renderResult={(g) => (
+                <>You got: <a href={`https://store.steampowered.com/app/${(g as Game).id}`} target="_blank" rel="noreferrer">{(g as Game).name}</a></>
             )}
-        </main>
+        />
     );
 }


### PR DESCRIPTION
## Summary
- add GeForce Now fetching utilities
- create a new `geforce-now` page that uses the same wheel logic
- add simple navigation to reach both pages
- refactor wheel component for reuse across pages

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684428a2d844832ca00d53e3416114f9